### PR TITLE
firefox-stable/google-chrome-stable: pkg_preinst -> pkg_postinst

### DIFF
--- a/recipes-browsers/firefox/firefox-stable_56.0.bb
+++ b/recipes-browsers/firefox/firefox-stable_56.0.bb
@@ -48,7 +48,7 @@ EOF
 	fi
 }
 
-pkg_preinst_${PN} () {
+pkg_postinst_${PN} () {
     #!/bin/sh -e
     if [ x"$D" != "x" ]; then
         echo "Cross install not supported"

--- a/recipes-browsers/google-chrome-stable/google-chrome-stable_0.1.bb
+++ b/recipes-browsers/google-chrome-stable/google-chrome-stable_0.1.bb
@@ -53,7 +53,7 @@ EOF
 	fi
 }
 
-pkg_preinst_${PN} () {
+pkg_postinst_${PN} () {
     #!/bin/sh -e
     if [ x"$D" != "x" ]; then
         echo "Cross install not supported"


### PR DESCRIPTION
There is a failure at do_rootfs time since pkg_preinst exit 1,
use pkg_postinst to replace, so the failed scriptlet will be
invoked at target fist boot.

There is not timing limit between pkg_preinst and pkg_postinst.
(just wget and tar)

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>